### PR TITLE
Bug: path not resolved before file check

### DIFF
--- a/ArcFormats/Emote/ImageDREF.cs
+++ b/ArcFormats/Emote/ImageDREF.cs
@@ -73,10 +73,9 @@ namespace GameRes.Formats.Emote
                     var match = PathRe.Match (line);
                     if (!match.Success)
                         return null;
-                    var pak_name = match.Groups[1].Value;
+                    var pak_name = VFS.CombinePath (dir, match.Groups[1].Value);
                     if (!VFS.FileExists (pak_name))
                         return null;
-                    pak_name = VFS.CombinePath (dir, pak_name);
                     layers.Add (Tuple.Create (pak_name, match.Groups[2].Value));
                 }
                 if (0 == layers.Count)


### PR DESCRIPTION
The `dpak` file path is currently not resolved before file check, which may cause some unexpected behaviors.

As a side note, this bug does not affect the GUI mode since in this case current working directory being the `dref` file location is always guaranteed.
However, this bug will cause some side programs such as `Image.Convert` to crash when dealing with input files of `dref` format.