### PR TITLE
Add NeXAS zlib support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: .NET Framework Build
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 jobs:
   build:
     runs-on: windows-latest

--- a/ArcFormats/ArcFormats.csproj
+++ b/ArcFormats/ArcFormats.csproj
@@ -14,6 +14,8 @@
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -102,6 +104,9 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="WindowsBase" />
+    <Reference Include="Zstandard.Net, Version=1.1.7.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Zstandard.Net.1.1.7\lib\net45\Zstandard.Net.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Abel\ArcARC.cs" />

--- a/ArcFormats/Nexas/ArcPAC.cs
+++ b/ArcFormats/Nexas/ArcPAC.cs
@@ -22,6 +22,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //
+// Zlib patch from https://github.com/morkt/GARbro/pull/464/files
 
 using System;
 using System.IO;
@@ -32,6 +33,7 @@ using System.ComponentModel.Composition;
 using GameRes.Compression;
 using GameRes.Formats.Strings;
 using GameRes.Utility;
+using Zstandard.Net;
 
 namespace GameRes.Formats.NeXAS
 {
@@ -42,6 +44,9 @@ namespace GameRes.Formats.NeXAS
         Huffman,
         Deflate,
         DeflateOrNone,
+        tmp1,
+        tmp2,
+        Zstd
     }
 
     public class PacArchive : ArcFile
@@ -169,13 +174,16 @@ namespace GameRes.Formats.NeXAS
 
         public override Stream OpenEntry (ArcFile arc, Entry entry)
         {
-            var input = arc.File.CreateStream (entry.Offset, entry.Size);
+            Stream input = arc.File.CreateStream (entry.Offset, entry.Size);
             var pac = arc as PacArchive;
             var pent = entry as PackedEntry;
             if (null == pac || null == pent || !pent.IsPacked)
                 return input;
-            switch (pac.PackType)
+            var it = pac.PackType;
+            switch (it)
             {
+            case Compression.None:
+                return input;
             case Compression.Lzss:
                 return new LzssStream (input);
 
@@ -187,6 +195,16 @@ namespace GameRes.Formats.NeXAS
                     var unpacked = HuffmanDecode (packed, (int)pent.UnpackedSize);
                     return new BinMemoryStream (unpacked, 0, (int)pent.UnpackedSize, entry.Name);
                 }
+            case Compression.Zstd:
+                {
+                    if (entry.Name.Contains(".png") ||
+                        entry.Name.Contains(".fnt") ||
+                        entry.Name.Contains(".ogg") ||
+                        entry.Name.Contains(".wav"))
+                        return input;
+                    return new ZstandardStream(input, System.IO.Compression.CompressionMode.Decompress);
+                }
+
             case Compression.Deflate:
             default:
                 return new ZLibStream (input, CompressionMode.Decompress);

--- a/ArcFormats/packages.config
+++ b/ArcFormats/packages.config
@@ -10,4 +10,5 @@
   <package id="System.Security.Cryptography.Algorithms" version="4.3.1" targetFramework="net46" />
   <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net46" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net46" />
+  <package id="Zstandard.Net" version="1.1.7" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
Patch adapted from https://github.com/morkt/GARbro/pull/464. Tested to work on _Seifuku Kanojo_ ([r121386](https://vndb.org/r121386) & [r121506](https://vndb.org/r121506)).

By the way, why do my local build & [ci artifact](https://github.com/Vinfall/GARbro/actions/runs/8599294365) miss those `*.lst` files in `GameData` folder? Is it due to missing perl executable in path or something else?