### PR TITLE
fix audio decode error on game つい・ゆり ～おかあさんにはナイショだよ～

### DIFF
--- a/ArcFormats/BlackCyc/AudioVAW.cs
+++ b/ArcFormats/BlackCyc/AudioVAW.cs
@@ -67,7 +67,15 @@ namespace GameRes.Formats.BlackCyc
             else if (2 == header.PackType)
             {
                 format = OggAudio.Instance;
-                offset = 0x6C;
+                file.Seek(0x6C, SeekOrigin.Begin);
+                if (0x4F == file.ReadByte())
+                {
+                    offset = 0x6C;
+                }
+                else
+                {
+                    offset = 0x6E;
+                }
             }
             else if (6 == header.PackType && Binary.AsciiEqual (header.Bytes, 0x10, "OGG "))
             {


### PR DESCRIPTION
game: つい・ゆり ～おかあさんにはナイショだよ～
fixed issue: .vaw audio file header containe extra 2 byte for "some" files, some are normal without 2 extra byte

Can please help verify does this affect other games?

[cdvaw.zip](https://github.com/user-attachments/files/18386583/cdvaw.zip)
