### PR TITLE
Add RGBA7 format handler

### DIFF
--- a/GameRes/Image.cs
+++ b/GameRes/Image.cs
@@ -213,14 +213,18 @@ namespace GameRes
             int src = 0;
             var color_map = new Color[colors];
             Func<int, Color> get_color;
-            if (PaletteFormat.Bgr == format || PaletteFormat.BgrX == format)
+            if (PaletteFormat.Bgr == format)
                 get_color = x => Color.FromRgb (palette_data[x+2], palette_data[x+1], palette_data[x]);
+            else if (PaletteFormat.BgrX == format)
+                get_color = x => Color.FromArgb(palette_data[x+3] >= byte.MaxValue / 2 ? byte.MaxValue : (byte)(palette_data[x+3] << 1), palette_data[x+2], palette_data[x+1], palette_data[x]);
             else if (PaletteFormat.BgrA == format)
                 get_color = x => Color.FromArgb (palette_data[x+3], palette_data[x+2], palette_data[x+1], palette_data[x]);
             else if (PaletteFormat.RgbA == format)
                 get_color = x => Color.FromArgb (palette_data[x+3], palette_data[x], palette_data[x+1], palette_data[x+2]);
+            else if (PaletteFormat.RgbX == format)
+                get_color = x => Color.FromArgb (palette_data[x+3] >= byte.MaxValue / 2 ? byte.MaxValue : (byte)(palette_data[x+3] << 1), palette_data[x], palette_data[x+1], palette_data[x+2]);
             else
-                get_color = x => Color.FromRgb (palette_data[x],   palette_data[x+1], palette_data[x+2]);
+                get_color = x => Color.FromRgb (palette_data[x], palette_data[x+1], palette_data[x+2]);
 
             for (int i = 0; i < colors; ++i)
             {

--- a/GameRes/Image.cs
+++ b/GameRes/Image.cs
@@ -71,6 +71,8 @@ namespace GameRes
         BgrX    = 6,
         RgbA    = 9,
         BgrA    = 10,
+        RgbA7 = 55,
+        BgrA7 = 66,
     }
 
     public class ImageData
@@ -213,15 +215,15 @@ namespace GameRes
             int src = 0;
             var color_map = new Color[colors];
             Func<int, Color> get_color;
-            if (PaletteFormat.Bgr == format)
+            if (PaletteFormat.Bgr == format || PaletteFormat.BgrX == format)
                 get_color = x => Color.FromRgb (palette_data[x+2], palette_data[x+1], palette_data[x]);
-            else if (PaletteFormat.BgrX == format)
+            else if (PaletteFormat.BgrA7 == format)
                 get_color = x => Color.FromArgb(palette_data[x+3] >= byte.MaxValue / 2 ? byte.MaxValue : (byte)(palette_data[x+3] << 1), palette_data[x+2], palette_data[x+1], palette_data[x]);
             else if (PaletteFormat.BgrA == format)
                 get_color = x => Color.FromArgb (palette_data[x+3], palette_data[x+2], palette_data[x+1], palette_data[x]);
             else if (PaletteFormat.RgbA == format)
                 get_color = x => Color.FromArgb (palette_data[x+3], palette_data[x], palette_data[x+1], palette_data[x+2]);
-            else if (PaletteFormat.RgbX == format)
+            else if (PaletteFormat.RgbA7 == format)
                 get_color = x => Color.FromArgb (palette_data[x+3] >= byte.MaxValue / 2 ? byte.MaxValue : (byte)(palette_data[x+3] << 1), palette_data[x], palette_data[x+1], palette_data[x+2]);
             else
                 get_color = x => Color.FromRgb (palette_data[x], palette_data[x+1], palette_data[x+2]);


### PR DESCRIPTION
The deep architecture of this program may be wrong with the handling of RGBX and BGRX color formats.
RGBX does not mean that the value of the transparency(Alpha) channel is meaningless, it means that the X/Alpha channel has 8bits, but the value is only 0~128 (0x80), which can be converted to RGBA by some methods.
This change may break some image format support, and further testing is recommended.