### PR TITLE
TIM2 format edit

### DIFF
--- a/ArcFormats/ArcFormats.csproj
+++ b/ArcFormats/ArcFormats.csproj
@@ -131,7 +131,9 @@
     <Compile Include="Artemis\ImageNekoPNG.cs" />
     <Compile Include="CsWare\AudioWAV.cs" />
     <Compile Include="CsWare\ImageGDT.cs" />
+    <Compile Include="DigitalWorks\ArcPACsingle.cs" />
     <Compile Include="DigitalWorks\ArcPACPS2.cs" />
+    <Compile Include="DigitalWorks\ImageTM2arc.cs" />
     <Compile Include="DxLib\HuffmanDecoder.cs" />
     <Compile Include="DxLib\WidgetDXA.xaml.cs">
       <DependentUpon>WidgetDXA.xaml</DependentUpon>

--- a/ArcFormats/DigitalWorks/ArcPACsingle.cs
+++ b/ArcFormats/DigitalWorks/ArcPACsingle.cs
@@ -1,0 +1,88 @@
+//! \file       ArcPACPS2.cs
+//! \date       2018 Sep 18
+//! \brief      Digital Works PS2 resource archive.
+//
+// Copyright (C) 2018 by morkt
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//
+
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.IO;
+using GameRes.Compression;
+
+namespace GameRes.Formats.DigitalWorks
+{
+    [Export(typeof(ArchiveFormat))]
+    public class PacSingleOpener : ArchiveFormat
+    {
+        public override string         Tag { get { return "PAC/LZS-TIM2"; } }
+        public override string Description { get { return "LZS-TIM2 Image archive"; } }
+        public override uint     Signature { get { return 0x535A4C; } } // 'LZS'
+        public override bool  IsHierarchic { get { return false; } }
+        public override bool      CanWrite { get { return false; } }
+
+        /**
+         Target games:
+        Cafe Little Wish SLPM-65294
+        F Fanatic SLPM-65296
+         */
+
+        public override ArcFile TryOpen (ArcView file)
+        {
+            if (!file.View.AsciiEqual(9, "TIM2"))
+                return null;
+            var dir = new List<Entry> (1);
+            var entry = FormatCatalog.Instance.Create<PackedEntry> (file.Name);
+            entry.Offset = 0L;
+            entry.Size   = (uint)file.MaxOffset;
+            if (!entry.CheckPlacement (file.MaxOffset))
+                return null;
+            dir.Add (entry);
+            
+            return new ArcFile (file, this, dir);    
+        }
+
+        public override Stream OpenEntry (ArcFile arc, Entry entry)
+        {
+            var pent = entry as PackedEntry;
+            if (null == pent)
+                return base.OpenEntry (arc, entry);
+            if (!pent.IsPacked)
+            {
+                if (!arc.File.View.AsciiEqual (entry.Offset, "LZS\0"))
+                    return base.OpenEntry (arc, entry);
+                pent.IsPacked = true;
+                pent.UnpackedSize = arc.File.View.ReadUInt32 (entry.Offset+4);
+            }
+            var input = arc.File.CreateStream (entry.Offset+8, entry.Size-8);
+            bool embedded_lzs = (input.Signature & ~0xF0u) == 0x535A4C0F; // 'LZS'
+            var lzs = new LzssStream (input);
+            if (embedded_lzs)
+            {
+                var header = new byte[8];
+                lzs.Read (header, 0, 8);
+                pent.UnpackedSize = header.ToUInt32 (4);
+                lzs = new LzssStream (lzs);
+            }
+            return lzs;
+        }
+    }
+}

--- a/ArcFormats/DigitalWorks/ImageTM2.cs
+++ b/ArcFormats/DigitalWorks/ImageTM2.cs
@@ -37,7 +37,7 @@ namespace GameRes.Formats.DigitalWorks
         public int  PaletteSize;
         public int  HeaderSize;
         public int  Colors;
-        public byte X_A;
+        public byte Alpha;
     }
 
     [Export(typeof(ImageFormat))]
@@ -87,7 +87,7 @@ namespace GameRes.Formats.DigitalWorks
                 PaletteSize = header.ToInt32 (0x14),
                 HeaderSize = header.ToUInt16 (0x1C),
                 Colors  = header.ToUInt16 (0x1E),
-                X_A = alpha, //header.ToUInt16(0x30) == 0?// not so sure, there will be omissions
+                Alpha = alpha, //header.ToUInt16(0x30) == 0?// not so sure, there will be omissions
             };
         }
 
@@ -132,9 +132,9 @@ namespace GameRes.Formats.DigitalWorks
             int image_size = (int)m_info.Width * (int)m_info.Height * pixel_size;
             var output = m_input.ReadBytes (image_size);
             if (pixel_size <= 8 && m_info.Colors > 0)
-                Palette = ReadPalette (m_info.Colors, m_info.X_A);
+                Palette = ReadPalette (m_info.Colors, m_info.Alpha);
 
-            if (pixel_size == 3 || pixel_size == 4 && m_info.X_A == 8)
+            if (pixel_size == 3 || pixel_size == 4 && m_info.Alpha == 8)
             {
                 for (int i = 0; i < image_size; i += pixel_size)
                 {
@@ -143,7 +143,7 @@ namespace GameRes.Formats.DigitalWorks
                     output[i+2] = r;
                 }
             }
-            if (pixel_size == 4 && m_info.X_A == 7)
+            if (pixel_size == 4 && m_info.Alpha == 7)
             {
                 for (int i = 0; i < image_size; i += 4)
                 {
@@ -156,7 +156,7 @@ namespace GameRes.Formats.DigitalWorks
                         output[i + 3] = (byte)(output[i + 3] << 1);
                 }
             }
-            if (pixel_size == 4 && m_info.X_A == 0)
+            if (pixel_size == 4 && m_info.Alpha == 0)
             {
                 for (int i = 0; i < image_size; i += 4)
                 {
@@ -172,7 +172,7 @@ namespace GameRes.Formats.DigitalWorks
         BitmapPalette ReadPalette (int color_num, byte X_A = 8)
         {
             var source = ImageFormat.ReadColorMap (m_input.AsStream,
-                color_num, X_A == 7 ? PaletteFormat.RgbX : X_A == 0 ? PaletteFormat.RgbX_Disposed : PaletteFormat.RgbA);
+                color_num, X_A == 7 ? PaletteFormat.RgbA7 : X_A == 0 ? PaletteFormat.RgbX : PaletteFormat.RgbA);
             var color_map = new Color[color_num];
 
             int parts = color_num / 32;

--- a/ArcFormats/DigitalWorks/ImageTM2arc.cs
+++ b/ArcFormats/DigitalWorks/ImageTM2arc.cs
@@ -1,0 +1,51 @@
+﻿using GameRes.Compression;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.IO;
+
+namespace GameRes.Formats.DigitalWorks
+{
+    [Export(typeof(ImageFormat))]
+    public class TM2ArkFormat : Tim2Format 
+    {
+        public override string Tag { get { return "TIM2/PS2 compressed"; } }
+        public override string Description { get { return "PlayStation/2 image format with LZSS compress"; } }
+        public override uint Signature { get { return 0x535A4C; } } // 'LZS'
+        public TM2ArkFormat()
+        {
+            Extensions = new string[] { "tm2" };
+        }
+        public override ImageMetaData ReadMetaData(IBinaryStream stream)
+        {
+            stream.Position = 9;
+            uint real_sign = stream.ReadUInt32();
+            //Tim2Format tm2raw = new Tim2Format();
+            if (real_sign != base.Signature)
+            {
+                return null;
+            }
+            stream.Position = 4;
+            uint unpacked_size = stream.ReadUInt32();
+            if (unpacked_size <= 0x20 || unpacked_size > 0x5000000) // ~83MB
+                return null;
+            stream.Position = 8;
+            using (var lzss = new LzssStream(stream.AsStream, LzssMode.Decompress, true))
+            using (var input = new SeekableStream(lzss))
+            using (var tm2 = new BinaryStream(input, stream.Name))
+                return base.ReadMetaData(tm2);
+        }
+        public override ImageData Read(IBinaryStream stream, ImageMetaData info)
+        {
+            stream.Position = 8;
+            using (var lzss = new LzssStream(stream.AsStream, LzssMode.Decompress, true))
+            using (var input = new SeekableStream(lzss))
+            using (var tm2 = new BinaryStream(input, stream.Name))
+                return base.Read(tm2, info);
+        }
+        public override void Write(Stream file, ImageData image)
+        {
+            throw new System.NotImplementedException("TM2ArkFormat.Write not implemented");
+        }
+    }
+}

--- a/ArcFormats/DigitalWorks/ImageTM2arc.cs
+++ b/ArcFormats/DigitalWorks/ImageTM2arc.cs
@@ -15,7 +15,9 @@ namespace GameRes.Formats.DigitalWorks
         public TM2ArkFormat()
         {
             Extensions = new string[] { "tm2" };
+            Settings = null;
         }
+
         public override ImageMetaData ReadMetaData(IBinaryStream stream)
         {
             stream.Position = 9;

--- a/ArcFormats/MAGES/ArcARC20.cs
+++ b/ArcFormats/MAGES/ArcARC20.cs
@@ -11,7 +11,7 @@ namespace GameRes.Formats.MAGES
         public override string Tag { get { return "ARC/Princess Soft ARC20"; } }
         public override string Description { get { return "Princess Soft PS2 resource archive"; } }
         public override uint Signature { get { return 0x20435241; } } // 'ARC\x20'
-        public override bool IsHierarchic { get { return false; } }
+        public override bool IsHierarchic { get { return true; } }
         public override bool CanWrite { get { return false; } }
 
         public override ArcFile TryOpen(ArcView file)

--- a/ArcFormats/Properties/Settings.Designer.cs
+++ b/ArcFormats/Properties/Settings.Designer.cs
@@ -837,5 +837,17 @@ namespace GameRes.Formats.Properties {
                 this["NexasEncodingCP"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("RGBA")]
+        public string TIM2AlphaFormat {
+            get {
+                return ((string)(this["TIM2AlphaFormat"]));
+            }
+            set {
+                this["TIM2AlphaFormat"] = value;
+            }
+        }
     }
 }

--- a/ArcFormats/Properties/Settings.settings
+++ b/ArcFormats/Properties/Settings.settings
@@ -206,5 +206,8 @@
     <Setting Name="NexasEncodingCP" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">932</Value>
     </Setting>
+    <Setting Name="TIM2AlphaFormat" Type="System.String" Scope="User">
+      <Value Profile="(Default)">RGBA</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/ArcFormats/Strings/arcStrings.Designer.cs
+++ b/ArcFormats/Strings/arcStrings.Designer.cs
@@ -753,6 +753,16 @@ namespace GameRes.Formats.Strings {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Choose Tim2 image alpha format.
+        ///   It can&apos;t be read correctly from the file.
+        /// </summary>
+        public static string Tim2AlphaFormat {
+            get {
+                return ResourceManager.GetString("Tim2AlphaFormat", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Hex number.
         /// </summary>
         public static string TooltipHex {

--- a/ArcFormats/Strings/arcStrings.ja-JP.resx
+++ b/ArcFormats/Strings/arcStrings.ja-JP.resx
@@ -501,4 +501,8 @@ Choose encryption scheme or enter a passphrase.</comment>
   <data name="ODNAudioSampleRate" xml:space="preserve">
     <value>Default audio sampling rate</value>
   </data>
+  <data name="Tim2AlphaFormat" xml:space="preserve">
+    <value>Tim2画像のAlpha形式を選択してください。
+ファイルから正しく読み取ることができません。</value>
+  </data>
 </root>

--- a/ArcFormats/Strings/arcStrings.resx
+++ b/ArcFormats/Strings/arcStrings.resx
@@ -401,4 +401,8 @@ Choose encryption scheme or enter a passphrase.</value>
   <data name="ODNAudioSampleRate" xml:space="preserve">
     <value>Default audio sampling rate</value>
   </data>
+  <data name="Tim2AlphaFormat" xml:space="preserve">
+    <value>Choose Tim2 image alpha format.
+It can't be read correctly from the file.</value>
+  </data>
 </root>

--- a/ArcFormats/Strings/arcStrings.zh-Hans.resx
+++ b/ArcFormats/Strings/arcStrings.zh-Hans.resx
@@ -399,4 +399,8 @@
   <data name="ODNAudioSampleRate" xml:space="preserve">
     <value>默认音频采样率</value>
   </data>
+  <data name="Tim2AlphaFormat" xml:space="preserve">
+    <value>选择Tim2图片透明度格式。
+这无法从文件中正确获取。</value>
+  </data>
 </root>

--- a/ArcFormats/app.config
+++ b/ArcFormats/app.config
@@ -208,6 +208,9 @@
             <setting name="NexasEncodingCP" serializeAs="String">
                 <value>932</value>
             </setting>
+            <setting name="TIM2AlphaFormat" serializeAs="String">
+              <value>RGBA</value>
+            </setting>
         </GameRes.Formats.Properties.Settings>
     </userSettings>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" /></startup>


### PR DESCRIPTION
**Please wait for PR #73 to complete before merging this PR.**

Improved support for Princess Soft TIM2 format, adding an option to allow users to select the correct transparency format.

REAL build status:
https://github.com/Manicsteiner/GARbro/tree/refs/heads/feat_tm2arc_test
https://github.com/Manicsteiner/GARbro/actions/runs/12844952651