### PR TITLE
Update ImageRMT.cs

### DIFF
--- a/ArcFormats/elf/ImageRMT.cs
+++ b/ArcFormats/elf/ImageRMT.cs
@@ -1,6 +1,6 @@
 //! \file       ImageRMT.cs
 //! \date       2017 Dec 11
-//! \brief      Ai5 engine compressed image format.
+//! \brief      Ai6 engine compressed image format.
 //
 // Copyright (C) 2017 by morkt
 //

--- a/ArcFormats/elf/ImageRMT.cs
+++ b/ArcFormats/elf/ImageRMT.cs
@@ -34,7 +34,7 @@ namespace GameRes.Formats.Elf
     public class RmtFormat : ImageFormat
     {
         public override string         Tag { get { return "RMT"; } }
-        public override string Description { get { return "Ai5 engine compressed image format"; } }
+        public override string Description { get { return "Ai6 engine compressed image format"; } }
         public override uint     Signature { get { return 0x20544D52; } } // 'RMT '
 
         public override ImageMetaData ReadMetaData (IBinaryStream file)


### PR DESCRIPTION
I unpacked many elf games and found that the rmt images are all game resources for the ai6win engine，but ImageRMT.cs description has been mistakenly written as the file format of the ai5 engine

https://morkt.github.io/GARbro/supported.html


