### PR TITLE
fix: F&C Soreiyu MCG v200 img dec

### DIFF
--- a/ArcFormats/FC01/ImageMCG.cs
+++ b/ArcFormats/FC01/ImageMCG.cs
@@ -269,9 +269,17 @@ namespace GameRes.Formats.FC01
         {
             m_output = new byte[m_pixels*3];
             var reader = new MrgDecoder (m_input, 0, (uint)m_pixels);
+            bool try_default_key = false;
             do
             {
-                reader.ResetKey (m_key);
+                if (!try_default_key)
+                {
+                    reader.ResetKey(Properties.Settings.Default.MCGLastKey);
+                }
+                else
+                {
+                    reader.ResetKey(m_key);
+                }
                 try
                 {
                     for (int i = 0; i < 3; ++i)
@@ -281,13 +289,22 @@ namespace GameRes.Formats.FC01
                         int src = 0;
                         for (int j = ChannelOrder[i]; j < m_output.Length; j += 3)
                         {
-                            m_output[j] = plane[src++];
+                                m_output[j] = plane[src++];
                         }
                     }
-//                    Trace.WriteLine (string.Format ("Found matching key {0:X2}", key), "[MCG]");
+                        Trace.WriteLine(string.Format("Found matching key {0:X2}", m_key), "[MCG]");
                 }
                 catch (InvalidFormatException)
                 {
+                    if (!try_default_key)
+                    {
+                        try_default_key = true;
+                        if (m_key == Properties.Settings.Default.MCGLastKey)
+                        {
+                            m_key++;
+                        }
+                        continue;
+                    }
                     m_key++;
                     continue;
                 }


### PR DESCRIPTION
Target game: それいゆ -PREMIE'RE- (PC) https://vndb.org/v5130

Problem: The compressed file contains both v101 and v200 versions of the image, and the v200 version’s content cannot be decoded (occasionally it can be successfully decoded using a tricky method, once).

Analysis: In the UnpackV200 method, the m_key input is usually 0. If the `Properties.Settings.Default.MCGLastKey` has not been selected beforehand, this value will be 0, which equals m_key. This causes the method to exit directly during the first loop and throw an exception. If MCGLastKey has been selected or the v101 version of the image has been decoded, the loop will trigger an exit condition after a few iterations with the previous key value and throw an exception.

Solution: Before attempting the key, first try using MCGLastKey, as both formats in this game share the same key. If successful, the process can return normally. If MCGLastKey is 0 and fails, then continue trying with m_key=1. If MCGLastKey is not 0 and still fails… does this situation even exist? In cases where the real key is greater than MCGLastKey, the issue cannot be properly handled. It is recommended to restart the process.