### PR TITLE
修正: Cyberworksにおけるtype d差分画像、及び非圧縮type b画像のデコードエラー

### DIFF
--- a/ArcFormats/Cyberworks/ArcDAT.cs
+++ b/ArcFormats/Cyberworks/ArcDAT.cs
@@ -460,7 +460,7 @@ namespace GameRes.Formats.Cyberworks
                     };
                     if (!entry.CheckPlacement (file.MaxOffset))
                         return null;
-                    entry.IsPacked = entry.UnpackedSize != entry.Size;
+                    entry.IsPacked = entry.UnpackedSize != entry.Size && entry.UnpackedSize != 0;
                     dir.Add (entry);
                 }
             }
@@ -637,7 +637,7 @@ namespace GameRes.Formats.Cyberworks
             var entry = new PackedEntry { Name = id.ToString ("D6") };
             entry.UnpackedSize = m_index.ReadUInt32();
             entry.Size = m_index.ReadUInt32();
-            entry.IsPacked = entry.UnpackedSize != entry.Size;
+            entry.IsPacked = entry.UnpackedSize != entry.Size && entry.UnpackedSize != 0;
             entry.Offset = m_index.ReadUInt32();
             return entry;
         }

--- a/ArcFormats/Cyberworks/ImageTINK.cs
+++ b/ArcFormats/Cyberworks/ImageTINK.cs
@@ -147,12 +147,18 @@ namespace GameRes.Formats.Cyberworks
                         var size_buf = new byte[4];
                         input.Read (size_buf, 0 , 4);
                         int png_size = BigEndian.ToInt32 (size_buf, 0);
-                        BitmapSource frame;
-                        // work-around for possible extra padding before PNG data
-                        using (var membuf = new MemoryStream (png_size+4))
+
+                        List<byte> mem_list;
+                        using (var membuf = new MemoryStream())
                         {
-                            input.CopyTo (membuf);
-                            membuf.Seek (-png_size, SeekOrigin.End);
+                            input.CopyTo(membuf);
+                            mem_list = membuf.ToArray().ToList();
+                            mem_list.RemoveRange(0, mem_list.Count - png_size);
+                        }
+
+                        BitmapSource frame;
+                        using (var membuf = new MemoryStream(mem_list.ToArray()))
+                        {
                             var decoder = new PngBitmapDecoder (membuf, BitmapCreateOptions.None,
                                                                 BitmapCacheOption.OnLoad);
                             frame = decoder.Frames[0];


### PR DESCRIPTION
下記ゲームタイトルにおいて、画像のアンパック中にエラーが発生したので、ソースコードの修正を提案します。

[220729][TinkerBell] 夢幻のさくら2
[230728][TinkerBell] せをはやみ。

～type d差分画像のデコードエラー～
アンパック対象の画像データがtype dの差分画像の場合、
ベースとなる画像(type c)を検索し、画像データを重ね合わせることになるのですが、
上記ゲームタイトルではそのベース画像のデータの直前(厳密にはpngシグネチャ：0x89504E47の直前)に0x00のパディングが埋め込まれています。
既存のソースコードではこのパディングを避けてデコードするために読み込んだStreamデータをMemoryStreamにコピーした後Seekしているのですが、PngBitmapDecoderではSeekで指定したPositionを無視して先頭バイトからデコードしようとするため、
デコードエラーとなってしまいます。
今回の修正では、MemoryStreamのSeekの代わりにパディングを削除する処理を追加しています。

～非圧縮type b画像のデコードエラー～
アンパック対象の画像データがLzssで圧縮されていない（非圧縮の）場合、
Arc02.datから読みだされるUnpackedSizeの値は0（UnpackedSize = Sizeではない）となるため、
圧縮されていないにもかかわらずLzssで解凍されてしまい、アンパックエラーとなってしまいます。
今回の修正では、IsPackedの判定条件に「UnpackedSize != 0」のAND条件を追加しています。



