### PR TITLE
Fix XP3 creation with RiddleCxCrypt

### DIFF
--- a/ArcFormats/KiriKiri/KiriKiriCx.cs
+++ b/ArcFormats/KiriKiri/KiriKiriCx.cs
@@ -164,6 +164,11 @@ namespace GameRes.Formats.KiriKiri
 
         public override void Decrypt (Xp3Entry entry, long offset, byte[] buffer, int pos, int count)
         {
+            CxDecryptCore (entry, offset, buffer, pos, count);
+        }
+
+        protected void CxDecryptCore (Xp3Entry entry, long offset, byte[] buffer, int pos, int count)
+        {
             uint key = entry.Hash;
             uint base_offset = GetBaseOffset (key);
             if (offset < base_offset)
@@ -204,7 +209,7 @@ namespace GameRes.Formats.KiriKiri
 
         public override void Encrypt (Xp3Entry entry, long offset, byte[] values, int pos, int count)
         {
-            Decrypt (entry, offset, values, pos, count);
+            CxDecryptCore (entry, offset, values, pos, count);
         }
 
         protected Tuple<uint, uint> ExecuteXCode (uint hash)


### PR DESCRIPTION
## Issue
The current XP3 `RiddleCxCrypt` _encryption_ is broken.

To reproduce, just create any XP3 pack that uses `RiddleCxCrypt` ("Riddle Joker" or "Café Stella to Shinigami no Chou"). Then you decrypt it and see that the file extracted is not the same as the original file.

For example, I created a pack with one file test.txt containing the following bytes:
```
30 31 32 33 34 35 36 37 38 39 41 42 43 44 45 46
```
Creating a XP3 with "Café Stella to Shinigami no Chou" crypt and then extracting it, the extracted test.txt has the following bytes:
```
83 a6 b6 8a 33 1b 35 9a 38 39 41 42 43 44 45 46
```
## Cause
Look at `GameRes.Formats.KiriKiri.RiddleCxCrypt.Encrypt`:

https://github.com/crskycode/GARbro/blob/71a938273f5186400a35d1c6cd5ba082c7765956/ArcFormats/KiriKiri/YuzCrypt.cs#L137-L141

`base.Encrypt` would call `GameRes.Formats.KiriKiri.CxEncryption.Encrypt`:

https://github.com/crskycode/GARbro/blob/71a938273f5186400a35d1c6cd5ba082c7765956/ArcFormats/KiriKiri/KiriKiriCx.cs#L205-L208

which would call `Decrypt` again as the algorithm is symmetric, but `Decrypt` is virtual and this would call `GameRes.Formats.KiriKiri.RiddleCxCrypt.Decrypt`:

https://github.com/crskycode/GARbro/blob/71a938273f5186400a35d1c6cd5ba082c7765956/ArcFormats/KiriKiri/YuzCrypt.cs#L131-L135

As you can tell from the process, `ProcessFirstBytes` gets invoked twice (once before the Cx crypt and once after) when it should have only been invoked once after the Cx crypt.

## Fix
Let `CxEncryption.Encrypt` call `CxEncryption`'s own implementation of `Decrypt` only. This fix should not break other crypts derived from `CxEncryption` as they don't call `base.Encrypt` or rely on the fact that `base.Encrypt` calls their `Decrypt`.