### PR TITLE
修正: ImagePNXのシグネチャ（0x2F2638E1 ⇒ 0）

### DIFF
--- a/ArcFormats/ImagePNX.cs
+++ b/ArcFormats/ImagePNX.cs
@@ -33,7 +33,7 @@ namespace GameRes.Formats.Misc
     {
         public override string         Tag { get { return "PNX"; } }
         public override string Description { get { return "Encrypted PNG image"; } }
-        public override uint     Signature { get { return 0x2F2638E1; } }
+        public override uint     Signature { get { return 0; } }
         public override bool      CanWrite { get { return false; } }
 
         public override ImageMetaData ReadMetaData (IBinaryStream file)


### PR DESCRIPTION
ソースコード：ImagePNX.csの修正を提案します。

ImagePNXはPNG画像データを任意のbyteデータでXOR暗号化した画像フォーマットとなります。
そのため、画像データ先頭4バイトのシグネチャは可変値となるため、
PnxFormatクラスのメンバ変数：Signatureは0に設定する必要があります。

以下はPnxFormatの基底クラスであるIResourceクラスに記述されているSignatureのコメントです。
「First 4 bytes of the resource file as little-endian 32-bit integer, or zero if it could vary.」