### PR TITLE
加筆: 吉里吉里 復号アルゴリズムの追加

### DIFF
--- a/ArcFormats/KiriKiri/CryptAlgorithms.cs
+++ b/ArcFormats/KiriKiri/CryptAlgorithms.cs
@@ -1671,4 +1671,23 @@ namespace GameRes.Formats.KiriKiri
         }
     }
 
+    [Serializable]
+    public class HoneyCombCrypt : ICrypt
+    {
+        public override void Decrypt(Xp3Entry entry, long offset, byte[] buffer, int pos, int count)
+        {
+            uint seed = entry.Hash ^ 0xABCD9876;
+            byte key = (byte)((seed >> 24) ^ (seed >> 16) ^ (seed >> 8) ^ seed);
+            if (key == 0)
+                key = 0xA5;
+            for (int i = 0; i < count; ++i)
+                buffer[pos + i] ^= key;
+        }
+
+        public override void Encrypt(Xp3Entry entry, long offset, byte[] values, int pos, int count)
+        {
+            Decrypt(entry, offset, values, pos, count);
+        }
+    }
+
 }


### PR DESCRIPTION
ソースコード：CryptAlgorithms.csへの加筆を提案します。

ALcot ハニカムで使用されている復号アルゴリズム（クラス名：HoneyCombCrypt）を追加しています。
本アルゴリズムを使用することにより、下記ゲームタイトルでのアンパックが可能となります。

[140829][ALcot ハニカム] サツコイ ～悠久なる恋の歌～
[141128][ALcot ハニカム] キミのとなりで恋してる！

また、SchemeToolのソースコードを添付していますので、必要に応じてご活用ください。

添付ファイル：SchemeToolソースコード（Program.cs）
[Program.zip](https://github.com/user-attachments/files/29837900/Program.zip)
