### PR TITLE
Fix ASAR parsing failure with unpacked entries

### DIFF
--- a/ArcFormats/ArcASAR.cs
+++ b/ArcFormats/ArcASAR.cs
@@ -41,6 +41,12 @@ namespace GameRes.Formats.Chromium
 
         [JsonProperty("offset")]
         public string Offset { get; set; }
+
+        [JsonProperty("unpacked")]
+        public bool Unpacked { get; set; }
+
+        [JsonProperty("link")]
+        public string Link { get; set; }
     }
 
     [Export(typeof(ArchiveFormat))]
@@ -59,17 +65,34 @@ namespace GameRes.Formats.Chromium
 
         public override ArcFile TryOpen (ArcView file)
         {
+            if (file.MaxOffset < 0x10)
+                return null;
             if (file.View.ReadUInt32 (4) != file.View.ReadUInt32 (8) + 4)
                 return null;
             uint index_size = file.View.ReadUInt32 (0x0C);
+            if (index_size > file.MaxOffset - 0x10)
+                return null;
             string json = file.View.ReadString (0x10, index_size, Encoding.UTF8);
-            var dict = JsonConvert.DeserializeObject<AsarNode> (json);
+            AsarNode dict;
+            try
+            {
+                dict = JsonConvert.DeserializeObject<AsarNode> (json);
+            }
+            catch (JsonException)
+            {
+                return null;
+            }
+            if (null == dict)
+                return null;
             var dir = new List<Entry> ();
-            ParseIndex (dir, dict, (uint)((index_size + 0x10 + 3) & ~3));
+            long pad = (0x10L + index_size + 3) & ~3L;
+            ParseIndex (dir, dict, pad);
+            dir.RemoveAll (e => e.Size != 0 && !e.CheckPlacement (file.MaxOffset));
             return new ArcFile (file, this, dir);
         }
 
-        internal void ParseIndex (List<Entry> dir, AsarNode dict, uint pad, string cur = "") {
+        void ParseIndex (List<Entry> dir, AsarNode dict, long pad, string cur = "")
+        {
             if (dict.Files != null)
             {
                 foreach (var kv in dict.Files)
@@ -81,10 +104,15 @@ namespace GameRes.Formats.Chromium
             }
             else
             {
+                if (dict.Unpacked || !string.IsNullOrEmpty (dict.Link) || string.IsNullOrEmpty (dict.Offset))
+                    return;
+                long offset;
+                if (!long.TryParse (dict.Offset, out offset))
+                    return;
                 var entry = new Entry {
                     Name = cur,
                     Size = dict.Size,
-                    Offset = uint.Parse (dict.Offset) + pad,
+                    Offset = offset + pad,
                     Type = FormatCatalog.Instance.GetTypeFromName (cur)
                 };
                 dir.Add (entry);


### PR DESCRIPTION
## Description

Fix Electron ASAR archives failing to open when they contain unpacked entries.

## Problem

GARbro already supports the ASAR format, but some valid Electron application archives cannot be opened.

For example:

- `Queens_Casino/resources/app.asar` (~977 MB)

The failure was caused by Electron's `asarUnpack` feature.  
`asarUnpack` is a supported and commonly used Electron packaging feature that stores selected files outside the ASAR archive in `app.asar.unpacked`.

These unpacked entries do not contain an `offset` field in the ASAR JSON index.

The previous implementation assumed every file node had an offset:


```csharp
Offset = uint.Parse(dict.Offset)
````


When encountering unpacked entries, this caused `ArgumentNullException`, preventing the entire archive from being opened.

## Changes

- Added `unpacked` and `link` fields to the ASAR node model.
- Skip unpacked/link nodes or nodes without valid offsets.
- Use `long.TryParse` for offsets to support larger ASAR archives.
- Added additional validation for truncated ASAR files and malformed JSON headers.
- Validate entry ranges during opening.